### PR TITLE
Updated with image/capture release and windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,50 @@ from your device.
 
 ### TODO
 Add support for Audio and IMU. Fix bugs. Accept PRs.
+
+## Instructions for Window Install
+This may not be the most elegant or minimal solution, but it worked for me on two different Windows 10 machines.
+
+### Prereqs.
+* You have the Kinect SDK installed and `k4viewer` works for you.
+	* Find (corresponding on your install) following directories/files:
+		* `C:\Program Files\Azure Kinect SDK v1.2.0\sdk\include\k4a`
+		* `C:\Program Files\Azure Kinect SDK v1.2.0\sdk\windows-desktop\x86\release\lib\k4a.lib`
+		* `C:\Program Files\Azure Kinect SDK v1.2.0\sdk\windows-desktop\x86\release\bin\k4a.dll`
+		* `C:\Program Files\Azure Kinect SDK v1.2.0\sdk\windows-desktop\x86\release\bin\k4a.pyd`
+		* `C:\Program Files\Azure Kinect SDK v1.2.0\sdk\windows-desktop\x86\release\bin\depthengine_2_0.dll`
+* You have Python 3.6 or newer development libraries installed. 
+	* This may be installed on your computer simply as Python.  
+	* Note the following directories and add them to your user Path
+		* `C:\Users\amy\AppData\Local\Programs\Python\Python37\include`
+		* `C:\Users\amy\AppData\Local\Programs\Python\Python37\DLLs`
+		* `C:\Users\amy\AppData\Local\Programs\Python\Python37\libs`
+* You have a C compiler
+	* e.g., VS2019 with C++ desktop development tools, C++/CLI, and most recent Windows 10 SDK installed
+		* Make sure your environmental variables are set, i.e. CMAKE_C_COMPILER should point to cl.exe inside VS2019
+			* e.g., `C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.23.28105\bin\Hostx86\x86\cl.exe`
+* Copy elements from the SDK to your Python directories and set environment and path variables
+	* Add following directory (equivalent on your machine) to your user Path
+		* `C:\Program Files\Azure Kinect SDK v1.2.0\sdk\include`
+		* at this time, make sure you also have the Python paths listed above
+	* Copy the k4a folder of the SDK to your Python "include" folder (see example directories above)
+	* Copy the k4a.dll and k4a.pyd of the SDK to your Python DLLs folder (see example directories above)
+	* Copy the k4a.lib to your Python lib folder (see example directories above)
+	* Create an environmental variable LINK pointing to k4a.lib, with quotes! 
+		* e.g., `"C:\Program Files\Azure Kinect SDK v1.2.0\sdk\windows-desktop\amd64\release\lib\k4a.lib"`
+* You have an Azure Kinect device
+
+### Build/Install
+```sh
+git clone https://github.com/brendandburns/py-k4a.git
+cd py-k4a
+python setup.py build
+python setup.py install
+python example.py
+```
+
+If all goes well, this will leave a file named `test.jpg` in your directory with a single frame capture
+from your device.
+
+### TODO
+Add support for Audio and IMU. Fix bugs. Accept PRs.

--- a/capture.c
+++ b/capture.c
@@ -81,3 +81,23 @@ PyObject* py_image_get_stride_bytes(PyObject* self, PyObject* args)
 
     return PyLong_FromLong(k4a_image_get_stride_bytes(obj->image));
 }
+
+PyObject* py_image_release(PyObject* self, PyObject* args)
+{
+    ImageObject* obj;
+    PyArg_ParseTuple(args, "O", &obj);
+
+    k4a_image_release(obj->image);
+
+    return Py_None;
+}
+
+PyObject* py_capture_release(PyObject* self, PyObject* args)
+{
+    CaptureObject* obj;
+    PyArg_ParseTuple(args, "O", &obj);
+
+    k4a_capture_release(obj->capture);
+
+    return Py_None;
+}

--- a/capture.h
+++ b/capture.h
@@ -14,4 +14,6 @@ PyObject* py_image_get_buffer(PyObject* self, PyObject* args);
 PyObject* py_image_get_width_pixels(PyObject* self, PyObject* args);
 PyObject* py_image_get_height_pixels(PyObject* self, PyObject* args);
 PyObject* py_image_get_stride_bytes(PyObject* self, PyObject* args);
+PyObject* py_image_release(PyObject* self, PyObject* args);
+PyObject* py_capture_release(PyObject* self, PyObject* args);
 #endif

--- a/example.py
+++ b/example.py
@@ -32,6 +32,9 @@ if k4a.device_open(0, dev):
                         fp.write(k4a.image_get_buffer(img))
                         fp.flush()
                         fp.close()
+
+                        k4a.image_release(img) #I think this is working
+                        k4a.capture_release(capture) #I don't think this is working
                 except:
                     import sys
                     print("Unexpected error:", sys.exc_info()[0])

--- a/module.c
+++ b/module.c
@@ -23,6 +23,8 @@ static PyMethodDef methods[] = {
     { "image_get_width_pixels", py_image_get_width_pixels, METH_VARARGS, "Get the image width"},
     { "image_get_height_pixels", py_image_get_height_pixels, METH_VARARGS, "Get the image height"},
     { "image_get_stride_bytes", py_image_get_stride_bytes, METH_VARARGS, "Get stride width in bytes"},
+    { "image_release", py_image_release, METH_VARARGS, "Release image"},
+    { "capture_release", py_capture_release, METH_VARARGS, "Release capture"},
     { NULL, NULL, 0, NULL }
 };
 


### PR DESCRIPTION
Included details on what I did to get this working on two Windows 10 machines (an older Dell and a new Lenovo). I also included the changes I made to implement image and capture release.  

Best I can tell: py_k4a_image_release() works but py_k4a_capture_release() does not; I added both to example.py where I think they should go.  This is working (with image_release and not without) if I pull images relatively slowly from the Kinect, e.g., at least a second apart, but if I want closer to realtime info, it's hit or miss (mostly miss).  Here are the kind of errors I'm getting:

[2019-10-06 18:56:48.692] [error] [t=2352] D:\a\1\s\extern\Azure-Kinect-Sensor-SDK\src\image\image.c (51): k4a_image_t_get_context(). Invalid k4a_image_t 04AC6DE0
[2019-10-06 18:56:48.692] [error] [t=2352] D:\a\1\s\extern\Azure-Kinect-Sensor-SDK\src\image\image.c (333): Invalid argument to image_dec_ref(). image_handle (04AC6DE0) is not a valid handle of type k4a_image_t

This may be something to do with not having capture_release.  I posted this issue over on the Microsoft SDK page as well.  Their reply: "My guess is that there is a marshalling issue between the C interface and the Python call.", which seems reasonable too.... but much harder to fix.  Going to post this issue under "Issues" with more detail too!